### PR TITLE
[#6] Introduce PlatformOutboundInstruction for Split and Merge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2019. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.axoniq</groupId>
     <artifactId>axon-server-api</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.1-SNAPSHOT</version>
     <name>Axon Server API</name>
     <description>Public API for communication with AxonServer</description>
 

--- a/src/main/proto/control.proto
+++ b/src/main/proto/control.proto
@@ -23,6 +23,8 @@ message PlatformOutboundInstruction {
         StartEventProcessor start_event_processor = 5;
         ReleaseEventProcessorSegment release_segment = 6;
         RequestEventProcessorInfo request_event_processor_info = 7;
+        SplitEventProcessorSegment split_event_processor_segment = 8;
+        MergeEventProcessorSegment merge_event_processor_segment = 9;
     }
 }
 
@@ -78,4 +80,14 @@ message ReleaseEventProcessorSegment {
 
 message RequestEventProcessorInfo {
     string processor_name = 1;
+}
+
+message SplitEventProcessorSegment {
+    string processor_name = 1;
+    int32 segment_identifier = 2;
+}
+
+message MergeEventProcessorSegment {
+    string processor_name = 1;
+    int32 segment_identifier = 2;
 }


### PR DESCRIPTION
Add a `SplitEventProcessorSegment` and `MergeEventProcessorSegment`, both taking in a 'processorName' and 'segmentId'. 
Additionally, add these operations to the `PlatformOutboundInstruction`'s list.

This PR resolves #6