### PR TITLE
Heartbeat improvements:  the axon framework version is sent to axon server.

### DIFF
--- a/src/main/proto/control.proto
+++ b/src/main/proto/control.proto
@@ -123,6 +123,9 @@ message ClientIdentification {
 
     /* Any tags associated with the client, which may provide hints and preferences for setting up connections */
     map<string, string> tags = 3;
+
+    /* Axon framework version used by the client application instance*/
+    string version = 4;
 }
 
 /* Message containing information about the status of a Tracking Event Processor */


### PR DESCRIPTION
This is performed in order to avoid communication overhead in case axon framework version
doesn't support the heartbeat functionality.
The version can be useful for many purposes in the future.