### PR TITLE
Instruction acknowlegdement

### DIFF
--- a/src/main/proto/command.proto
+++ b/src/main/proto/command.proto
@@ -33,8 +33,8 @@ message CommandProviderOutbound {
         /* Sends a result of Command processing */
         CommandResponse command_response = 4;
 
-        /* Acknowledgement result of previously sent instruction via inbound stream */
-        InstructionAck result = 5;
+        /* Acknowledgement of previously sent instruction via inbound stream */
+        InstructionAck ack = 5;
     }
 
     /* Instruction identifier. If this identifier is set, this instruction will be acknowledged via inbound stream */
@@ -46,8 +46,8 @@ message CommandProviderInbound {
     /* The instruction from AxonServer for this component */
     oneof request {
 
-        /* Acknowledgement result of previously sent instruction via outbound stream */
-        InstructionAck result = 1;
+        /* Acknowledgement of previously sent instruction via outbound stream */
+        InstructionAck ack = 1;
 
         /* A command for this component to process */
         Command command = 2;

--- a/src/main/proto/command.proto
+++ b/src/main/proto/command.proto
@@ -33,11 +33,11 @@ message CommandProviderOutbound {
         /* Sends a result of Command processing */
         CommandResponse command_response = 4;
 
-        /* Represents a result of previously sent instruction */
-        InstructionResult result = 5;
+        /* Acknowledgment result of previously sent instruction via inbound stream */
+        InstructionAck result = 5;
     }
 
-    /* Instruction identifier */
+    /* Instruction identifier. If this identifier is set, this instruction will be acknowledged via inbound stream */
     string instruction_id = 6;
 }
 
@@ -46,14 +46,14 @@ message CommandProviderInbound {
     /* The instruction from AxonServer for this component */
     oneof request {
 
-        /* An acknowledgement of an instruction sent via the Outbound channel */
-        InstructionResult result = 1;
+        /* Acknowledgment result of previously sent instruction via outbound stream */
+        InstructionAck result = 1;
 
         /* A command for this component to process */
         Command command = 2;
     }
 
-    /* Instruction identifier */
+    /* Instruction identifier. If this identifier is set, this instruction will be acknowledged via outbound stream */
     string instruction_id = 3;
 }
 

--- a/src/main/proto/command.proto
+++ b/src/main/proto/command.proto
@@ -33,7 +33,7 @@ message CommandProviderOutbound {
         /* Sends a result of Command processing */
         CommandResponse command_response = 4;
 
-        /* Acknowledgment result of previously sent instruction via inbound stream */
+        /* Acknowledgement result of previously sent instruction via inbound stream */
         InstructionAck result = 5;
     }
 
@@ -46,7 +46,7 @@ message CommandProviderInbound {
     /* The instruction from AxonServer for this component */
     oneof request {
 
-        /* Acknowledgment result of previously sent instruction via outbound stream */
+        /* Acknowledgement result of previously sent instruction via outbound stream */
         InstructionAck result = 1;
 
         /* A command for this component to process */

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -96,15 +96,15 @@ message FlowControl {
     int64 permits = 3;
 }
 
-/* Message describing a result of instruction processing */
-message InstructionResult {
+/* Message describing instruction acknowledgment */
+message InstructionAck {
 
     /* The identifier of the instruction */
     string instruction_id = 1;
 
-    /* Indicator whether the instruction was handled successfully */
+    /* Indicator whether the instruction was acknowledged successfully */
     bool success = 2;
 
-    /* Set if instruction handling failed. */
+    /* Set if instruction acknowledgment failed. */
     ErrorMessage error = 3;
 }

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -96,7 +96,7 @@ message FlowControl {
     int64 permits = 3;
 }
 
-/* Message describing instruction acknowledgment */
+/* Message describing instruction acknowledgement */
 message InstructionAck {
 
     /* The identifier of the instruction */
@@ -105,6 +105,6 @@ message InstructionAck {
     /* Indicator whether the instruction was acknowledged successfully */
     bool success = 2;
 
-    /* Set if instruction acknowledgment failed. */
+    /* Set if instruction acknowledgement failed. */
     ErrorMessage error = 3;
 }

--- a/src/main/proto/control.proto
+++ b/src/main/proto/control.proto
@@ -38,7 +38,7 @@ message PlatformInboundInstruction {
         /* This heartbeat is used by AxonServer in order to check if the connection is still alive*/
         Heartbeat heartbeat = 3;
 
-        /* Acknowledgment result of previously sent instruction via outbound stream */
+        /* Acknowledgement result of previously sent instruction via outbound stream */
         InstructionAck result = 4;
     }
 
@@ -82,7 +82,7 @@ message PlatformOutboundInstruction {
         /* This heartbeat is used by AxonFramework in order to check if the connection is still alive*/
         Heartbeat heartbeat = 10;
 
-        /* Acknowledgment result of previously sent instruction via inbound stream */
+        /* Acknowledgement result of previously sent instruction via inbound stream */
         InstructionAck result = 11;
     }
 

--- a/src/main/proto/control.proto
+++ b/src/main/proto/control.proto
@@ -38,8 +38,8 @@ message PlatformInboundInstruction {
         /* This heartbeat is used by AxonServer in order to check if the connection is still alive*/
         Heartbeat heartbeat = 3;
 
-        /* Acknowledgement result of previously sent instruction via outbound stream */
-        InstructionAck result = 4;
+        /* Acknowledgement of previously sent instruction via outbound stream */
+        InstructionAck ack = 4;
     }
 
     /* Instruction identifier. If this identifier is set, this instruction will be acknowledged via outbound stream */
@@ -82,8 +82,8 @@ message PlatformOutboundInstruction {
         /* This heartbeat is used by AxonFramework in order to check if the connection is still alive*/
         Heartbeat heartbeat = 10;
 
-        /* Acknowledgement result of previously sent instruction via inbound stream */
-        InstructionAck result = 11;
+        /* Acknowledgement of previously sent instruction via inbound stream */
+        InstructionAck ack = 11;
     }
 
     /* Instruction identifier. If this identifier is set, this instruction will be acknowledged via inbound stream */

--- a/src/main/proto/control.proto
+++ b/src/main/proto/control.proto
@@ -38,11 +38,11 @@ message PlatformInboundInstruction {
         /* This heartbeat is used by AxonServer in order to check if the connection is still alive*/
         Heartbeat heartbeat = 3;
 
-        /* Result of previously sent instruction via outbound stream */
-        InstructionResult result = 4;
+        /* Acknowledgment result of previously sent instruction via outbound stream */
+        InstructionAck result = 4;
     }
 
-    /* Instruction identifier */
+    /* Instruction identifier. If this identifier is set, this instruction will be acknowledged via outbound stream */
     string instruction_id = 5;
 }
 
@@ -82,11 +82,11 @@ message PlatformOutboundInstruction {
         /* This heartbeat is used by AxonFramework in order to check if the connection is still alive*/
         Heartbeat heartbeat = 10;
 
-        /* Result of previously sent instruction via Inbound stream */
-        InstructionResult result = 11;
+        /* Acknowledgment result of previously sent instruction via inbound stream */
+        InstructionAck result = 11;
     }
 
-    /* Instruction identifier */
+    /* Instruction identifier. If this identifier is set, this instruction will be acknowledged via inbound stream */
     string instruction_id = 12;
 }
 

--- a/src/main/proto/query.proto
+++ b/src/main/proto/query.proto
@@ -43,11 +43,11 @@ message QueryProviderOutbound {
         /* Sends a response for a Subscription Query that has been received via the inbound stream */
         SubscriptionQueryResponse subscription_query_response = 6;
 
-        /* Result of previously sent Inbound instruction */
-        InstructionResult result = 7;
+        /* Acknowledgment result of previously sent instruction via inbound stream */
+        InstructionAck result = 7;
     }
 
-    /* Instruction identifier */
+    /* Instruction identifier. If this identifier is set, this instruction will be acknowledged via inbound stream */
     string instruction_id = 8;
 }
 
@@ -57,8 +57,8 @@ message QueryProviderInbound {
     /* The actual query or instruction */
     oneof request {
 
-        /* Confirmation of a request sent towards AxonServer */
-        InstructionResult result = 1;
+        /* Acknowledgment result of previously sent instruction via outbound stream */
+        InstructionAck result = 1;
 
         /* Represents an incoming Query, for which this component is expected to provide a response */
         QueryRequest query = 2;
@@ -67,7 +67,7 @@ message QueryProviderInbound {
         SubscriptionQueryRequest subscription_query_request = 3;
     }
 
-    /* Instruction identifier */
+    /* Instruction identifier. If this identifier is set, this instruction will be acknowledged via outbound stream */
     string instruction_id = 4;
 }
 

--- a/src/main/proto/query.proto
+++ b/src/main/proto/query.proto
@@ -43,8 +43,8 @@ message QueryProviderOutbound {
         /* Sends a response for a Subscription Query that has been received via the inbound stream */
         SubscriptionQueryResponse subscription_query_response = 6;
 
-        /* Acknowledgement result of previously sent instruction via inbound stream */
-        InstructionAck result = 7;
+        /* Acknowledgement of previously sent instruction via inbound stream */
+        InstructionAck ack = 7;
     }
 
     /* Instruction identifier. If this identifier is set, this instruction will be acknowledged via inbound stream */
@@ -57,8 +57,8 @@ message QueryProviderInbound {
     /* The actual query or instruction */
     oneof request {
 
-        /* Acknowledgement result of previously sent instruction via outbound stream */
-        InstructionAck result = 1;
+        /* Acknowledgement of previously sent instruction via outbound stream */
+        InstructionAck ack = 1;
 
         /* Represents an incoming Query, for which this component is expected to provide a response */
         QueryRequest query = 2;

--- a/src/main/proto/query.proto
+++ b/src/main/proto/query.proto
@@ -43,7 +43,7 @@ message QueryProviderOutbound {
         /* Sends a response for a Subscription Query that has been received via the inbound stream */
         SubscriptionQueryResponse subscription_query_response = 6;
 
-        /* Acknowledgment result of previously sent instruction via inbound stream */
+        /* Acknowledgement result of previously sent instruction via inbound stream */
         InstructionAck result = 7;
     }
 
@@ -57,7 +57,7 @@ message QueryProviderInbound {
     /* The actual query or instruction */
     oneof request {
 
-        /* Acknowledgment result of previously sent instruction via outbound stream */
+        /* Acknowledgement result of previously sent instruction via outbound stream */
         InstructionAck result = 1;
 
         /* Represents an incoming Query, for which this component is expected to provide a response */


### PR DESCRIPTION
Renamed InstructionResult to InstructionAck. The purpose of this message is only to acknowledge the reception of the instruction. Further on, instruction_id should be set only for instructions that expect acknowledgement.