### PR TITLE
Adjusted JavaDoc for ListEvents.

### DIFF
--- a/src/main/proto/event.proto
+++ b/src/main/proto/event.proto
@@ -22,7 +22,9 @@ service EventStore {
     rpc ListAggregateSnapshots (GetAggregateSnapshotsRequest) returns (stream Event) {
     }
 
-    // Retrieves the Events from a given tracking token. Results are streamed rather than returned at once.
+    /* Retrieves the Events from a given tracking token. However, if several GetEventsRequests are sent in the stream
+     only first one will create the tracker, others are used for increasing number of permits or blacklisting. Results
+     are streamed rather than returned at once. */
     rpc ListEvents (stream GetEventsRequest) returns (stream EventWithToken) {
     }
 


### PR DESCRIPTION
Clearly stated why input stream for ListEvents is used for.