### PR TITLE
Add the token_store_identifier field in the EventProcessorInfo message.

### DIFF
--- a/src/main/proto/control.proto
+++ b/src/main/proto/control.proto
@@ -192,6 +192,9 @@ message EventProcessorInfo {
        Will report 0 if all threads are assigned a Segment.
      */
     int32 available_threads = 7;
+
+    /* The Token Store Identifier if available. This is only provided by Tracking Event Processors.*/
+    string token_store_identifier = 8;
 }
 
 /* Message providing reference to an Event Processor */


### PR DESCRIPTION
This field is important to uniquely identity a Tracking Event Processor.