### PR TITLE
Add a flag to support persistent errors

### DIFF
--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -82,6 +82,9 @@ message ErrorMessage {
 
     /* An Error Code identifying the type of error */
     string error_code = 4;
+
+    /* Indicator whether the error is persistent. Persistent errors imply that the same error will consistently be returned if the same input is supplied */
+    bool persistent = 5;
 }
 
 /* Message used for Flow Control instruction, providing the counterpart with additional permits for sending messages */


### PR DESCRIPTION
Added `persistent` flag to `ErrorMessage` to be able to distinguish persistent (non-transient) and temporary (transient) exceptions.

The default for this field is false, so the errors will be transient unless otherwise specified.