### PR TITLE
Add isStreaming to EventProcessorInfo

### DIFF
--- a/.github/close-label.yml
+++ b/.github/close-label.yml
@@ -1,0 +1,4 @@
+"Type: Bug": "Status: Resolved"
+"Type: Enhancement": "Status: Resolved"
+"Type: Feature": "Status: Resolved"
+"Type: Dependency Upgrade": "Status: Resolved"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    # Specify labels for pull requests
+    labels:
+      - "Type: Dependency Upgrade"
+      - "Priority 1: Must"
+      - "Status: In Progress"
+    # Add reviewers
+    reviewers:
+      - "MGathier"
+    milestone: 7

--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,0 +1,20 @@
+releasenotes:
+  sections:
+    - title: "Features"
+      emoji: ":star:"
+      labels: [ "Type: Feature" ]
+    - title: "Enhancements"
+      emoji: ":chart_with_upwards_trend:"
+      labels: [ "Type: Enhancement" ]
+    - title: "Bug Fixes"
+      emoji: ":beetle:"
+      labels: [ "Type: Bug" ]
+    - title: "Dependency Upgrade"
+      emoji: ":hammer_and_wrench:"
+      labels: [ "Type: Dependency Upgrade" ]
+  issues:
+    exclude:
+      labels: [ "Type: Incorrect Repository", "Type: Question" ]
+  contributors:
+    exclude:
+      names: [ "dependabot" ]

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,68 @@
+name: Axon Server API
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    name: Test and Build on JDK 11
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+          server-id: sonatype
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Cache .m2
+        uses: actions/cache@v2.1.3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven
+
+      - name: Maven
+        run: |
+          mvn -B -U clean verify
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy to Sonatype
+        if: github.github.head_ref == null && success()
+        run: |
+          mvn -B -U deploy -DskipTests=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_ID }}
+          MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASS }}
+
+      - name: Notify success to Slack
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1.1.2
+        with:
+          channel_id: C015XFURSJU
+          status: SUCCESS
+          color: good
+
+      - name: Notify failure to Slack
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1.1.2
+        with:
+          channel_id: C015XFURSJU
+          status: FAILED
+          color: danger

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,33 @@
+# Trigger the workflow on milestone events
+on:
+  milestone:
+    types: [ closed ]
+name: Milestone Closure
+jobs:
+  create-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Create Release Notes Markdown
+        uses: docker://decathlon/release-notes-generator-action:2.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          OUTPUT_FOLDER: temp_release_notes
+          USE_MILESTONE_TITLE: "true"
+      - name: Get the name of the created Release Notes file and extract Version
+        run: |
+          RELEASE_NOTES_FILE=$(ls temp_release_notes/*.md | head -n 1)
+          echo "RELEASE_NOTES_FILE=$RELEASE_NOTES_FILE" >> $GITHUB_ENV
+          VERSION=$(echo ${{ github.event.milestone.title }} | cut -d' ' -f2)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Create a Draft Release Notes on GitHub
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: axon-server-extension-api-${{ env.VERSION }}
+          release_name: Axon Server Extension API v${{ env.VERSION }}
+          body_path: ${{ env.RELEASE_NOTES_FILE }}
+          draft: true

--- a/src/main/proto/control.proto
+++ b/src/main/proto/control.proto
@@ -30,8 +30,8 @@ message PlatformInboundInstruction {
          */
         ClientIdentification register = 1;
 
-        /* Information about Tracking Processors defined in the application.
-           This information is used by AxonServer to monitor the progress of Tracking Processors across instances.
+        /* Information about Processors defined in the application.
+           This information is used by Axon Server to monitor the progress of Event Processors across instances.
          */
         EventProcessorInfo event_processor_info = 2;
 
@@ -64,22 +64,22 @@ message PlatformOutboundInstruction {
          */
         RequestReconnect request_reconnect = 3;
 
-        /* Instruction from AxonServer to Pause a Tracking Event Processor. */
+        /* Instruction from AxonServer to Pause a Streaming Event Processor. */
         EventProcessorReference pause_event_processor = 4;
 
-        /* Instruction from AxonServer to Start a Tracking Event Processor. */
+        /* Instruction from AxonServer to Start a Streaming Event Processor. */
         EventProcessorReference start_event_processor = 5;
 
-        /* Instruction from AxonServer to Release a specific segment in a Tracking Event Processor */
+        /* Instruction from AxonServer to Release a specific segment in a Streaming Event Processor */
         EventProcessorSegmentReference release_segment = 6;
 
-        /* A request from AxonServer for status information of a specific Tracking Event Processor */
+        /* A request from AxonServer for status information of a specific Streaming Event Processor */
         EventProcessorReference request_event_processor_info = 7;
 
-        /* Instruction to split a Segment in a Tracking Event Processor */
+        /* Instruction to split a Segment in a Streaming Event Processor */
         EventProcessorSegmentReference split_event_processor_segment = 8;
 
-        /* Instruction to merge two Segments in a Tracking Event Processor */
+        /* Instruction to merge two Segments in a Streaming Event Processor */
         EventProcessorSegmentReference merge_event_processor_segment = 9;
 
         /* This heartbeat is used by AxonFramework in order to check if the connection is still alive*/
@@ -144,10 +144,10 @@ message ClientIdentification {
     string version = 4;
 }
 
-/* Message containing information about the status of a Tracking Event Processor */
+/* Message containing information about the status of an Event Processor */
 message EventProcessorInfo {
 
-    /* Message containing information about the status of a Segment of a Tracking Event Processor */
+    /* Message containing information about the status of a Segment of a Streaming Event Processor */
     message SegmentStatus {
         /* The ID of the Segment for which the status is reported */
         int32 segment_id = 1;
@@ -183,7 +183,7 @@ message EventProcessorInfo {
     /* Flag indicating whether the processor, when stopped, did so because of an irrecoverable Error */
     bool error = 5;
 
-    /* Status details of each of the Segments for which Events are being processed. This is only provided by Tracking
+    /* Status details of each of the Segments for which Events are being processed. This is only provided by Streaming
        Event Processors.
      */
     repeated SegmentStatus segment_status = 6;
@@ -193,8 +193,13 @@ message EventProcessorInfo {
      */
     int32 available_threads = 7;
 
-    /* The Token Store Identifier if available. This is only provided by Tracking Event Processors.*/
+    /* The Token Store Identifier if available. This is only provided by Streaming Event Processors.*/
     string token_store_identifier = 8;
+
+    /* Flag indicating whether the processor is a Streaming Event Processor.
+       This dictates whether streaming operations, like split and merge, are supported by this processor.
+     */
+    bool is_streaming_processor = 9;
 }
 
 /* Message providing reference to an Event Processor */


### PR DESCRIPTION
Currently, when ingesting an `EventProcessorInfo`, the consumer needs to check the `mode` field to deduce what type of event processor we're dealing with.
This works in the two-type environment (being the `SubscribingEventProcessor` and `TrackingEventProcessor`), but complicates as soon as new instances are added.
Specifically in how to portray what kind of Event Processor operations are available.

As a solution, we should add a flag indicating whether we are dealing with a streaming event processor yes/no.
If this flag is true, we are certain the `SegmentStatus` is provided, for example, as well as that the operations like split and merge can be performed.
If the flag is false, no of the above is the case.

Next to adjusting the `control.proto` to comply with these changes, I have added some GitHub Repository specific files.
More specifically, things like dependabot, the release-notes action and the main maven action (which also releases snapshots).