### PR TITLE
Return a stream (i.o. a single message) to allow server to complete without results.

### DIFF
--- a/src/main/proto/admin.proto
+++ b/src/main/proto/admin.proto
@@ -178,11 +178,13 @@ message ApplicationOverview {
 //***************************** Event Processor Admin Service ***************************
 
 service EventProcessorAdminService {
-  rpc PauseEventProcessor(EventProcessorIdentifier) returns (google.protobuf.Empty);
-  rpc StartEventProcessor(EventProcessorIdentifier) returns (google.protobuf.Empty);
-  rpc SplitEventProcessor(EventProcessorIdentifier) returns (google.protobuf.Empty);
-  rpc MergeEventProcessor(EventProcessorIdentifier) returns (google.protobuf.Empty);
+  /*The following api return a stream of Empty to allow the server to complete the stream without any result.*/
+  rpc PauseEventProcessor(EventProcessorIdentifier) returns (stream google.protobuf.Empty);
+  rpc StartEventProcessor(EventProcessorIdentifier) returns (stream google.protobuf.Empty);
+  rpc SplitEventProcessor(EventProcessorIdentifier) returns (stream google.protobuf.Empty);
+  rpc MergeEventProcessor(EventProcessorIdentifier) returns (stream google.protobuf.Empty);
 }
+
 message EventProcessorIdentifier {
   string processor_name = 1;
   string token_store_identifier = 2;


### PR DESCRIPTION
Return a stream of Empty to allow the server to complete the stream without any result.