### PR TITLE
add csharp namespace to each proto file

### DIFF
--- a/src/main/proto/admin.proto
+++ b/src/main/proto/admin.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package io.axoniq.axonserver.grpc.admin;
 import "google/protobuf/empty.proto";
 option java_multiple_files = true;
+option csharp_namespace = "AxonIQ.AxonServer.Grpc.Admin";
 
 //************************ ContextAdminService *****************************
 

--- a/src/main/proto/command.proto
+++ b/src/main/proto/command.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package io.axoniq.axonserver.grpc.command;
 import "common.proto";
 option java_multiple_files = true;
+option csharp_namespace = "AxonIQ.AxonServer.Grpc.Command";
 
 /* The CommandService defines the gRPC requests necessary for subscribing command handlers, and dispatching commands. */
 service CommandService {

--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package io.axoniq.axonserver.grpc;
 import "google/protobuf/any.proto";
 option java_multiple_files = true;
+option csharp_namespace = "AxonIQ.AxonServer.Grpc";
 
 /* Describes a serialized object */
 message SerializedObject {

--- a/src/main/proto/control.proto
+++ b/src/main/proto/control.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package io.axoniq.axonserver.grpc.control;
 import "common.proto";
 option java_multiple_files = true;
+option csharp_namespace = "AxonIQ.AxonServer.Grpc.Control";
 
 /* Service describing operations for connecting to the AxonServer platform.
 

--- a/src/main/proto/event.proto
+++ b/src/main/proto/event.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package io.axoniq.axonserver.grpc.event;
 import "common.proto";
 option java_multiple_files = true;
+option csharp_namespace = "AxonIQ.AxonServer.Grpc.Event";
 
 /* Service providing operations against the EventStore functionality of Axon Server */
 service EventStore {

--- a/src/main/proto/query.proto
+++ b/src/main/proto/query.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package io.axoniq.axonserver.grpc.query;
 import "common.proto";
 option java_multiple_files = true;
+option csharp_namespace = "AxonIQ.AxonServer.Grpc.Query";
 
 /* Service providing operations for the Query Messaging component of AxonServer */
 service QueryService {


### PR DESCRIPTION
This PR adds a C# namespace to each proto file (in preparation for the dotnet-connector).