### PR TITLE
Adding context to event processor Id

### DIFF
--- a/src/main/proto/admin.proto
+++ b/src/main/proto/admin.proto
@@ -290,6 +290,9 @@ message EventProcessorIdentifier {
 
   /* the identifier of the token store this event processor is using */
   string token_store_identifier = 2;
+
+  /* the context name where the processor is located */
+  string context_name = 3;
 }
 
 message MoveSegment {

--- a/src/main/proto/admin.proto
+++ b/src/main/proto/admin.proto
@@ -291,7 +291,7 @@ message EventProcessorIdentifier {
   /* the identifier of the token store this event processor is using */
   string token_store_identifier = 2;
 
-  /* the context name where the processor is located */
+  /* optional paameter to pass in the context name to indicate where the processor is located */
   string context_name = 3;
 }
 


### PR DESCRIPTION
The change is needed to perform operations on a given context instead of current context