### PR TITLE
fix: removing any.proto import from common.proto

### DIFF
--- a/src/main/proto/common.proto
+++ b/src/main/proto/common.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 package io.axoniq.axonserver.grpc;
-import "google/protobuf/any.proto";
 option java_multiple_files = true;
 
 /* Describes a serialized object */


### PR DESCRIPTION
When trying to generate the source files from the proto files, I got this warning:

```
common.proto:3:1: warning: Import google/protobuf/any.proto is unused.
```

I think it can safely be removed, unless I am missing something.