### PR TITLE
Add a timestamp to Snapshot to align with Event Store API

### DIFF
--- a/src/main/proto/dcb.proto
+++ b/src/main/proto/dcb.proto
@@ -307,11 +307,17 @@ message Snapshot {
   /* The name of the snapshot. */
   string name = 1;
 
-  /* The revision of the snapshot. */
-  string revision = 2;
+  /* The version of the snapshot. */
+  string version = 2;
 
   /* The payload of the snapshot. */
   bytes payload = 3;
+
+  /* The timestamp of the snapshot. */
+  int64 timestamp = 4;
+
+  /* The metadata of the snapshot. */
+  map<string, string> metadata = 5;
 }
 
 /* The request to add the snapshot to the snapshot store. */


### PR DESCRIPTION
The current implementation of the Snapshot Store API does not include timestamp and metadata fields. These fields are useful for searching snapshots or debugging times. Furthermore, metadata could be used for tracking the object creation throughout the systems.