### PR TITLE
Add LicenseService gRPC API for license distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.axoniq</groupId>
     <artifactId>axon-server-api</artifactId>
-    <version>2025.2.1-SNAPSHOT</version>
+    <version>2026.0.0-SNAPSHOT</version>
     <name>Axon Server API</name>
     <description>Public API for communication with AxonServer</description>
 

--- a/src/main/proto/license.proto
+++ b/src/main/proto/license.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+package io.axoniq.axonserver.grpc.license;
+option java_multiple_files = true;
+
+service LicenseService {
+
+    rpc GetLicense (GetLicenseRequest) returns (GetLicenseResponse);
+
+    rpc SubscribeLicenseUpdates (GetLicenseRequest) returns (stream GetLicenseResponse);
+
+}
+
+message GetLicenseRequest {
+}
+
+message GetLicenseResponse {
+    string license_content = 1;
+    LicenseStatus status = 2;
+}
+
+enum LicenseStatus {
+    AVAILABLE = 0;
+    UNAVAILABLE = 1;
+}

--- a/src/main/proto/license.proto
+++ b/src/main/proto/license.proto
@@ -2,17 +2,25 @@ syntax = "proto3";
 package io.axoniq.axonserver.grpc.license;
 option java_multiple_files = true;
 
+// Service for retrieving Axon Server license information.
 service LicenseService {
 
+    // Retrieves the current license details.
     rpc GetLicense (GetLicenseRequest) returns (GetLicenseResponse);
 
+    // Opens a server-streaming subscription that emits the current license
+    // followed by updates whenever the license changes.
     rpc SubscribeLicenseUpdates (GetLicenseRequest) returns (stream GetLicenseResponse);
 
 }
 
+// Request message for license operations.
 message GetLicenseRequest {
 }
 
+// Response message containing the license information.
 message GetLicenseResponse {
+
+    // The full license content as a string.
     string license_content = 1;
 }

--- a/src/main/proto/license.proto
+++ b/src/main/proto/license.proto
@@ -15,10 +15,4 @@ message GetLicenseRequest {
 
 message GetLicenseResponse {
     string license_content = 1;
-    LicenseStatus status = 2;
-}
-
-enum LicenseStatus {
-    AVAILABLE = 0;
-    UNAVAILABLE = 1;
 }

--- a/src/main/proto/license.proto
+++ b/src/main/proto/license.proto
@@ -8,10 +8,6 @@ service LicenseService {
     // Retrieves the current license details.
     rpc GetLicense (GetLicenseRequest) returns (GetLicenseResponse);
 
-    // Opens a server-streaming subscription that emits the current license
-    // followed by updates whenever the license changes.
-    rpc SubscribeLicenseUpdates (GetLicenseRequest) returns (stream GetLicenseResponse);
-
 }
 
 // Request message for license operations.


### PR DESCRIPTION
Add LicenseService gRPC proto definition for license fetching and streaming updates (from 2026.x.x version)

Relates: https://github.com/AxonIQ/axoniq-platform/issues/331